### PR TITLE
Fix path bugs

### DIFF
--- a/pytreebank/download.py
+++ b/pytreebank/download.py
@@ -56,6 +56,6 @@ def download_sst(path, url):
     utils.urlretrieve(url, zip_local)
     ZipFile(zip_local).extractall(path)
     for fname in local_files.values():
-        move(join(path, 'trainDevTestTrees_PTB', 'trees', fname.split('/')[-1]), fname)
+        move(join(path, 'trees', fname.split('/')[-1]), fname)
     delete_paths([zip_local, join(path, 'trainDevTestTrees_PTB', 'trees'), join(path, 'trainDevTestTrees_PTB')])
     return local_files


### PR DESCRIPTION
When I was using the version 0.2.4, and use the following command in ipython on macos, there is this bugs with tracebacks:
```
In [6]: dataset = pytreebank.load_sst("./")
---------------------------------------------------------------------------
FileNotFoundError                         Traceback (most recent call last)
/Users/mingyao/anaconda/envs/tensorflow/lib/python3.5/shutil.py in move(src, dst, copy_function)
    537     try:
--> 538         os.rename(src, real_dst)
    539     except OSError:

FileNotFoundError: [Errno 2] No such file or directory: './trainDevTestTrees_PTB/trees/dev.txt' -> './dev.txt'

During handling of the above exception, another exception occurred:

FileNotFoundError                         Traceback (most recent call last)
<ipython-input-6-37dfe8a72d6d> in <module>()
----> 1 dataset = pytreebank.load_sst("./")

~/anaconda/envs/tensorflow/lib/python3.5/site-packages/pytreebank/parse.py in load_sst(path, url)
    112         path = os.path.expanduser("~/stanford_sentiment_treebank/")
    113         makedirs(path, exist_ok=True)
--> 114     fnames = download_sst(path, url)
    115     return {key: import_tree_corpus(value) for key, value in fnames.items()}
    116

~/anaconda/envs/tensorflow/lib/python3.5/site-packages/pytreebank/download.py in download_sst(path, url)
     81     ZipFile(zip_local).extractall(path)
     82     for fname in local_files.values():
---> 83         move(join(path, 'trainDevTestTrees_PTB', 'trees', fname.split('/')[-1]), fname)
     84     delete_paths([zip_local, join(path, 'trainDevTestTrees_PTB', 'trees'), join(path, 'trainDevTestTrees_PTB')])
     85     return local_files

~/anaconda/envs/tensorflow/lib/python3.5/shutil.py in move(src, dst, copy_function)
    550             rmtree(src)
    551         else:
--> 552             copy_function(src, real_dst)
    553             os.unlink(src)
    554     return real_dst

~/anaconda/envs/tensorflow/lib/python3.5/shutil.py in copy2(src, dst, follow_symlinks)
    249     if os.path.isdir(dst):
    250         dst = os.path.join(dst, os.path.basename(src))
--> 251     copyfile(src, dst, follow_symlinks=follow_symlinks)
    252     copystat(src, dst, follow_symlinks=follow_symlinks)
    253     return dst

~/anaconda/envs/tensorflow/lib/python3.5/shutil.py in copyfile(src, dst, follow_symlinks)
    112         os.symlink(os.readlink(src), dst)
    113     else:
--> 114         with open(src, 'rb') as fsrc:
    115             with open(dst, 'wb') as fdst:
    116                 copyfileobj(fsrc, fdst)

FileNotFoundError: [Errno 2] No such file or directory: './trainDevTestTrees_PTB/trees/dev.txt'
```

And it was fixed with this commit.
Not sure whether it's the same case on other os.